### PR TITLE
Update Caddyfile + README

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,14 @@
 {
 	admin off
+	# Uncomment the below to use the staging Lets Encrypt server while testing
+	#acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+
+	#log {
+	#	output discard
+	#}
 }
 
 {$FACEPROX_HOSTNAME} {
-	log {
-		output discard
-		# Uncomment the below to use the staging Lets Encrypt server while testing
-		#acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
-	}
 	tls {$FACEPROX_TLS}
 	header {
 		# Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alternatively you can build a docker image by cloning this repository, building 
 
 If you just want to run this with an SSL certificate using docker-compose:
 
-- Edit the [.env](.env) file to set the hostname and an email
+- Edit the [.env](.env) file to set the hostname and an email (Ensure that the hostname is prefixed with `https://`)
 - Check everything is working: `docker-compose up`
 
 ## Usage


### PR DESCRIPTION
- Updates the Caddyfile to move global options to global block
- Updates the README to make it clear that the domain must be prefixed with `https://`

This fixes the Caddy server not properly fetching a HTTPS cert

Mind you, I'm not 100% sure that those options can't appear in a log block?